### PR TITLE
Support client served from file://

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -142,7 +142,7 @@ export function listen(channel: unknown, origins: string[], messageListener: Mes
       return
     }
 
-    const postOrigin = origin === 'null' ? '*' : origin;
+    const postOrigin = origin === 'null' ? '*' : origin
 
     if ('data' in data) {
       messageListener(data.data, source as IPostMessageImplementor, postOrigin)

--- a/index.ts
+++ b/index.ts
@@ -141,9 +141,13 @@ export function listen(channel: unknown, origins: string[], messageListener: Mes
     if (!('handshake' in data) && !('data' in data)) {
       return
     }
+    
+    if (origin === 'null') {
+      origin = '*'
+    }
 
     if ('data' in data) {
-      messageListener(data.data, source as IPostMessageImplementor, origin === 'null' ? '*' : origin)
+      messageListener(data.data, source as IPostMessageImplementor, origin)
     }
 
     (event.source as IPostMessageImplementor).postMessage({

--- a/index.ts
+++ b/index.ts
@@ -142,17 +142,17 @@ export function listen(channel: unknown, origins: string[], messageListener: Mes
       return
     }
 
-    const postOrigin = origin === 'null' ? '*' : origin
+    const messageOrigin = origin === 'null' ? '*' : origin
 
     if ('data' in data) {
-      messageListener(data.data, source as IPostMessageImplementor, postOrigin)
+      messageListener(data.data, source as IPostMessageImplementor, messageOrigin)
     }
 
     (event.source as IPostMessageImplementor).postMessage({
       channel,
       messageId: data.messageId,
       received: true,
-    }, postOrigin)
+    }, messageOrigin)
   })
 }
 

--- a/index.ts
+++ b/index.ts
@@ -142,19 +142,17 @@ export function listen(channel: unknown, origins: string[], messageListener: Mes
       return
     }
 
-    if (origin === 'null') {
-      origin = '*'
-    }
+    const postOrigin = origin === 'null' ? '*' : origin;
 
     if ('data' in data) {
-      messageListener(data.data, source as IPostMessageImplementor, origin)
+      messageListener(data.data, source as IPostMessageImplementor, postOrigin)
     }
 
     (event.source as IPostMessageImplementor).postMessage({
       channel,
       messageId: data.messageId,
       received: true,
-    }, origin)
+    }, postOrigin)
   })
 }
 

--- a/index.ts
+++ b/index.ts
@@ -141,7 +141,7 @@ export function listen(channel: unknown, origins: string[], messageListener: Mes
     if (!('handshake' in data) && !('data' in data)) {
       return
     }
-    
+
     if (origin === 'null') {
       origin = '*'
     }


### PR DESCRIPTION
When the client is served from the local filesytem, origin will be `'null'` which is an invalid target origin for postMessage.